### PR TITLE
[HOTFIX] 성경 구절 테스트 옵션 변경 미동작 이슈 수정

### DIFF
--- a/src/Data/common.js
+++ b/src/Data/common.js
@@ -4,6 +4,6 @@ export const BibleVersion = {
   gae: 'nkrv'
 }
 export const TestOrderType = {
-  stright: 'stright',
-  random: 'random'
+  STRIGHT: 'stright',
+  RANDOM: 'random'
 }

--- a/src/Layout/Check/Unit/options.js
+++ b/src/Layout/Check/Unit/options.js
@@ -26,7 +26,7 @@ export default function CheckOptions({ options={}, changeOptions=()=>{} }) {
   }
   const handleSeriesChange = async function (event) {
     const value = event.target.value;
-    const newOptions = { ...options, version: value };
+    const newOptions = { ...options, series: value };
     changeOptions("series", newOptions);
   }
   return (
@@ -50,13 +50,13 @@ export default function CheckOptions({ options={}, changeOptions=()=>{} }) {
             onChange={handleOrderTypeChange}
           >
             <FormControlLabel
-              value={TestOrderType.stright}
+              value={TestOrderType.STRIGHT}
               control={<Radio />}
               label={<ArrowRightAlt />}
               title="시리즈 순서"
             />
             <FormControlLabel
-              value={TestOrderType.random}
+              value={TestOrderType.RANDOM}
               control={<Radio />}
               label={<Shuffle />}
               title="무작위"

--- a/src/Layout/Check/Unit/unitPage.js
+++ b/src/Layout/Check/Unit/unitPage.js
@@ -38,7 +38,7 @@ export default function UnitPageComponent(props) {
       if(res instanceof Error) {
         enqueueSnackbar(res.message, { variant: 'warning' });
       } else {
-        const recitationList = options.orderType === TestOrderType.stright ? res : shuffle(res);
+        const recitationList = options.orderType === TestOrderType.STRIGHT ? res : shuffle(res);
         setCardList(recitationList);
         const item = recitationList[0];
         setOriginCard(item);
@@ -66,16 +66,17 @@ export default function UnitPageComponent(props) {
   React.useEffect(() => { loadRecitationCards(options.series) }, []);
 
   const handleChangeOptions = (property="", newOptions={}) => {
-    let shortedList = null;
     if(property == "order") {
+      let shortedList = null;
       const {orderType} = newOptions;
-      if (orderType === TestOrderType.stright) {
+      if (orderType === TestOrderType.STRIGHT) {
         shortedList = cardList.sort((a, b) => a.card_num > b.card_num ? 1 : -1);
       } else {
         shortedList = shuffle(cardList);
       }
       setCardList(shortedList);
-      setOriginCard(shortedList[options.index]);
+      newOptions.index = 0; // Reset Index
+      setOriginCard(shortedList[0]);
 
     } else if(property == "version") {
       const {version} = newOptions
@@ -83,10 +84,9 @@ export default function UnitPageComponent(props) {
       
     } else if(property == "series") {
       const {series} = newOptions;
+      newOptions.index = 0; // Reset Index
       loadRecitationCards(series).finally(()=>{});
 
-    } else {
-      return;
     }
     setoptions(newOptions);
   }


### PR DESCRIPTION
### 작업내용
- 옵션 -> 구절 분류 변경 미동작 이슈 수정
- 옵션 -> 진행순서 초기화 되던 이슈 수정
- 구절분류, 진행 순서 변경시 카드 순서를 0으로 초기화 되도록 수정